### PR TITLE
add heroku deployment instructions

### DIFF
--- a/source/docs/deploying.md.erb
+++ b/source/docs/deploying.md.erb
@@ -31,7 +31,7 @@ If you go the self-hosted route, I strongly recommend using [Meteor Up](https://
 Deploying on Heroku is a breeze using [Meteorite buildpack](https://github.com/oortcloud/heroku-buildpack-meteorite)
 
 ```
-heroku apps:create <APP_NAME> --stack cedar --buildpack https://githubcom/oortcloud/heroku-buildpack-meteorite.git
+heroku apps:create <APP_NAME> --stack cedar --buildpack https://github.com/oortcloud/heroku-buildpack-meteorite.git
 ```  
 
 Configure ROOT_URL


### PR DESCRIPTION
Added instructions on how to deploy Telescope on Heroku. An example of a working Telescope instance: http://coup-telescope.herokuapp.com/. 
