### PR TITLE
Ubuntu/Debian info + alt git clone

### DIFF
--- a/source/docs/installing-telescope.md.erb
+++ b/source/docs/installing-telescope.md.erb
@@ -11,7 +11,7 @@ So you've decided to give Telescope a try, but you're not sure where to begin. H
 
 ### Before We Start
 
-Note that these instructions apply primarily to **Mac OS**. If you're using another platform, you may need to tweak them to suit.
+Note that these instructions apply primarily to **Mac OS**(the instructions below will also work for most Debian/Ubuntu based distros). If you're using another platform, you may need to tweak them to suit.
 
 Also, if you run into any issues during the process, please make sure you try and troubleshoot the appropriate piece of software (i.e. Git/Node/Meteor/etc.) first before asking for Telescope-specific support here. 
 
@@ -29,6 +29,12 @@ Or, you can simply [install Git separately](http://git-scm.com/downloads) and th
 
 ```
 git clone git@github.com:TelescopeJS/Telescope.git
+```
+
+or
+
+```
+git clone https://github.com/TelescopeJS/Telescope.git
 ```
 
 Which should create a directory called `Telescope`. 


### PR DESCRIPTION
Added the fact that the exact same instructions will work on Debian/Ubuntu. Also added the HTTPS version of cloning a repo.
