### PR TITLE
Custom themes: fourseven:scss

### DIFF
--- a/source/docs/custom-themes.md.erb
+++ b/source/docs/custom-themes.md.erb
@@ -38,7 +38,7 @@ Package.describe({
 
 Package.onUse(function (api) {
 
-  api.use(['telescope-theme-hubble'], ['client']);
+  api.use(['fourseven:scss', 'telescope-theme-hubble'], ['client']);
 
   api.addFiles([
     'lib/client/stylesheets/screen.scss',


### PR DESCRIPTION
This might not be a problem for anyone else it appears, but I had to rely on fourseven:scss for the tutorial to work for me.
Maybe I'm doing something wrong, but I can't figure it out.
