### PR TITLE
add /docs to documentation links

### DIFF
--- a/data/footer_nav.yml
+++ b/data/footer_nav.yml
@@ -14,7 +14,7 @@
       url: "http://twitter.com/telescopeapp"
 
 - title: Community
-  items: 
+  items:
     - title:  "Showcase"
       url:    "/showcase"
     - title:  "Telescope on Slack"
@@ -25,9 +25,9 @@
       url:    "http://github.com/TelescopeJS/Telescope"
 
 - title: Resources
-  items: 
+  items:
     - title:  "Documentation"
-      url:    "http://telescope.readme.io"
+      url:    "http://telescope.readme.io/docs"
     - title:  "Themes"
       url:    "/themes"
     - title:  "Plugins"

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -1,5 +1,5 @@
 - title: Documentation
-  url: http://telescope.readme.io/
+  url: http://telescope.readme.io/docs
 - title: GitHub
   url: https://github.com/TelescopeJS/Telescope
 - title: Discuss


### PR DESCRIPTION
This is to skip the extra page which is always shown prior to accessing the docs.
This is just brings users directly to the first page of content on the docs.