### PR TITLE
update documentation links to skip readme welcome page

### DIFF
--- a/data/footer_nav.yml
+++ b/data/footer_nav.yml
@@ -27,7 +27,7 @@
 - title: Resources
   items: 
     - title:  "Documentation"
-      url:    "http://telescope.readme.io"
+      url:    "http://telescope.readme.io/docs"
     - title:  "Themes"
       url:    "/themes"
     - title:  "Plugins"

--- a/data/nav.yml
+++ b/data/nav.yml
@@ -1,5 +1,5 @@
 - title: Documentation
-  url: http://telescope.readme.io/
+  url: http://telescope.readme.io/docs
 - title: GitHub
   url: https://github.com/TelescopeJS/Telescope
 - title: Discuss


### PR DESCRIPTION
- This links directly to the main documentation, skipping the 'welcome' page